### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,9 +1,11 @@
 name: CI
+
 on:
+  # run on every push to main
   push:
     branches:
     - main
-    - main-new
+  # run on every push (not commit) to a PR, plus open/reopen
   pull_request:
     types:
     - synchronize
@@ -11,27 +13,24 @@ on:
     - reopened
 
 jobs:
-
-  # Run the black code checker
-  black:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: psf/black@stable
-
   build:
-    # Build with multiple (recent) versions of python on latest OSs
-    name: Build (${{ matrix.python-version }} | ${{ matrix.os }})
+    name: Build & test (${{ matrix.python-version }} | ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+
     strategy:
+      # continue testing other configurations even if a matrix job fails
+      fail-fast: false
       matrix:
+        # latest python on Win/Mac/Lin
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.10"]
+        # test older python versions on Linux only
         include:
         - os: ubuntu-latest
           python-version: "3.9"
         - os: ubuntu-latest
           python-version: "3.8"
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -42,20 +41,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint>=2.16 mypy>=1.0 pydocstyle>=6.3 pytest
+        pip install mypy>=1.0 pytest
         python -m pip install .
-    
-    - name: Lint with pylint
-      if: always()
-      run: pylint --disable=all --enable=unused-import .
 
-    - name: mypy 
+    - name: mypy
       if: always()
       run: mypy --strict .
-
-    - name: Check Docstrings
-      if: always()
-      run: pydocstyle --convention=numpy .
 
     - name: Run tests
       if: always()

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,0 +1,35 @@
+name: lint
+
+on:
+  # run on every push to main
+  push:
+    branches:
+    - main
+  # run on every push (not commit) to a PR, plus open/reopen
+  pull_request:
+    types:
+    - synchronize
+    - opened
+    - reopened
+
+jobs:
+  various:
+    name: various (Black, pylint, pydocstyle)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - run: pip install black pylint pydocstyle
+
+    # annotate each step with `if: always` to run all regardless
+    - name: Assert that code matches Black code style
+      if: always()
+      uses: psf/black@stable
+    - name: Lint with pylint
+      if: always()
+      run: pylint .
+    - name: Lint with pydocstyle
+      if: always()
+      run: pydocstyle --convention=numpy .


### PR DESCRIPTION
CI workflow

- [x] format with black
- [x] lint with pylint
- [x] run mypy
- [x] use pydocstyle with numpy for docstrings
- [x] run tests with pytest

Questions:
- Can we change so black and linting only performed in one version/OS and tests performed on all?
- May need to alter to install dependencies as work done in #9 
- Currently runs when a PR is opened to `main` or `main-new`