### PR TITLE
Addresses oom_issue in data processing for large --ntimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ Relevant parameters:
 * `factor`: the factor definining the low-resolution grid of the generated data
   with respect to the high-resolution grid.
 * `CO2`: 0 for control, 1 for 1% increase per year dataset.
-* `global`: TODO "make data cyclic along longitude"
+* `global`: TODO "make data cyclic along longitude". Set to 0; currently fails when set to 1.
+* `ntimes`: the number of days to process, knowing that the data set is at a
+  time resolution of one per day. If not specified, uses the complete dataset.
+* `lat_min`, `lat_max`, `lon_min`, `lon_max`: the spatial domain to process.
 
 Direct call (without MLflow) example:
 

--- a/pyproject-poetry.toml
+++ b/pyproject-poetry.toml
@@ -89,6 +89,9 @@ gcsfs = "*"
 torch = "^1.13.1"
 progressbar2 = "^4.2.0"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.0"
+
 [build-system]
 #requires = ["setuptools >= 61"]
 #build-backend = "setuptools.build_meta"

--- a/src/gz21_ocean_momentum/cmip26.py
+++ b/src/gz21_ocean_momentum/cmip26.py
@@ -138,12 +138,6 @@ forcing = forcing.sel(
     xu_ocean=slice(bounds[2], bounds[3]), yu_ocean=slice(bounds[0], bounds[1])
 )
 
-# chunk_sizes = list(map(int, params.chunk_size.split('/')))
-# while len(chunk_sizes) < 3:
-#     chunk_sizes.append('auto')
-# forcing = forcing.chunk(dict(zip(('time', 'xu_ocean', 'yu_ocean'),
-#                                  chunk_sizes)))
-
 for var in forcing:
     forcing[var].encoding = {}
 forcing = forcing.chunk(dict(time=1))

--- a/src/gz21_ocean_momentum/cmip26.py
+++ b/src/gz21_ocean_momentum/cmip26.py
@@ -112,38 +112,8 @@ logger.debug("Mapping blocks")
 debug_mode = os.environ.get("DEBUG_MODE")
 if params.factor != 0 and not debug_mode:
     scale_m = params.factor
-
-    def func(block):
-        """
-        Description: Apply coarsening operations + computations of subgrid
-            momentum forcing to a chunk of data along the time axis.
-
-        Parameters
-        ----------
-        block :
-            description: an xarray dataset containing variables usurf and vsurf
-            for the two components of surface velocities.
-
-        Returns
-        -------
-        eddy_forcing : xr.Dataset
-            Dataset containing 4 variables:
-            - usurf and vsurf, the two components of the coarse-grained & filtered
-            surface velocities
-            - S_x and S_y, the two components of the diagnosed subgrid momentum
-            forcing
-        """
-        return eddy_forcing(block, grid_data, scale=scale_m)
-
-    template = patch_data.coarsen(
-        {"xu_ocean": int(scale_m), "yu_ocean": int(scale_m)}, boundary="trim"
-    ).mean()
-    template2 = template.copy()
-    template2 = template2.rename({"usurf": "S_x", "vsurf": "S_y"})
-    template = xr.merge((template, template2))
-    forcing = xr.map_blocks(func, patch_data, template=template)
-    # forcing = eddy_forcing(patch_data, grid_data, scale=scale_m, method='mean',
-    #                        scale_mode='factor')
+    forcing = eddy_forcing(patch_data, grid_data, scale=scale_m, method='mean',
+                           scale_mode='factor')
 elif not debug_mode:
     scale_m = params.scale * 1e3
     forcing = eddy_forcing(patch_data, grid_data, scale=scale_m, method="mean")
@@ -173,6 +143,10 @@ forcing = forcing.sel(
 #     chunk_sizes.append('auto')
 # forcing = forcing.chunk(dict(zip(('time', 'xu_ocean', 'yu_ocean'),
 #                                  chunk_sizes)))
+
+for var in forcing:
+    forcing[var].encoding = {}
+forcing = forcing.chunk(dict(time=1))
 
 logger.info("Preparing forcing data")
 logger.debug(forcing)

--- a/tests/data/test_coarse.py
+++ b/tests/data/test_coarse.py
@@ -53,6 +53,27 @@ class TestEddyForcing:
 
         assert data["a"].values == pytest.approx(filtered_data["a"].values)
 
+    def test_eddy_forcing_chunks(self):
+        """
+        Check that the computations are done along the spatial dimensions.
+        """
+        data = np.stack(np.zeros(100, 100), np.ones(100, 100), axis=0)
+        a1 = xr.DataArray(data=data,
+                       dims = ['time', 'x', 'y'],
+                       coords = {'time' : np.arange(1000) * 3,
+                                 'x' : np.arange(100) * 10,
+                                 'y' : np.arange(100) * 11})
+        a2 = xr.DataArray(data = data,
+                       dims = ['time', 'x', 'y'],
+                       coords = {'time' : np.arange(1000) * 3,
+                                 'x' : np.arange(100) * 10,
+                                 'y' : np.arange(100) * 11})
+        ds = xr.Dataset({'usurf' : a1, 'vsurf' : a2})
+        forcing = eddy_forcing(ds, 40)
+        usurf_0, usurf_1 = forcing.usurf.isel(time=0), forcing.usurf.isel(time=1)
+        assert np.all(usurf_0 == 0)
+        assert not np.all(usurf_1 == 0)
+
     # def test_spatial_filter_dataset(self):
     #     a1 = xr.DataArray(data = np.zeros((10, 4, 4)),
     #                    dims = ['time', 'x', 'y'],

--- a/tests/data/test_coarse.py
+++ b/tests/data/test_coarse.py
@@ -110,8 +110,8 @@ class TestEddyForcing:
 
         scale_m = 1
 
-        xs = np.arange(100)
-        ys = np.arange(100) * 2
+        xs = np.random.rand(100)
+        ys = np.random.rand(100) * 2
         times = np.arange(2)
         xs_, ys_ = np.meshgrid(xs, ys)
         dxs = np.ones_like(xs_)


### PR DESCRIPTION
This closes #47. 

Currently, the following command 

`python src/gz21_ocean_momentum/cmip26.py -85 85 -280 80 --factor 4 --ntimes 10
`
runs fine, but fails if we increase --ntimes to 100 (both on personal laptop and HPC job with 30GB RAM). 

The data is meant to be processed using the function [eddy_forcing ](https://github.com/m2lines/GZ21_ocean_momentum_CNN/blob/ff51084b2856f84b8e0a1aa0990ddcfb84c2c7c1/src/gz21_ocean_momentum/data/coarse.py#L116), which takes as input the high-resolution dataset of surface velocities, and returns the
processed dataset lazily. The reason is that the whole dataset does not fit in the memory, but the computations are carried out along spatial dimensions only. 

This means that Dask should be able to load in ram a few times slices, apply the function to those and write the corresponding partial result onto the disk in zarr format.

