### PR TITLE
Fix mistake in README.md re install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ environment. In the root directory:
     virtualenv venv
     source venv/bin/activate
 
-Alternatively, if you are using python to virtual environments using the `venv` module then the first line above can be replaced by `python -m venv venv`.
+Alternatively, if you are using python to manage virtual environments using the `venv` module, then the first line above can be replaced by `python -m venv venv` (where the second `venv` is the virtual environment name).
 
 See [virtualenv docs](https://virtualenv.pypa.io/en/latest/) for more details.
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ Python 3 is required.
 #### Python
 With `pip` installed, run the following in the root directory:
 
-    pip install -e
+    pip install -e .
 
 To avoid any conflicts with local packages, we recommend using a virtual
 environment. In the root directory:
 
     virtualenv venv
     source venv/bin/activate
+
+Alternatively, if you are using python to virtual environments using the `venv` module then the first line above can be replaced by `python -m venv venv`.
 
 See [virtualenv docs](https://virtualenv.pypa.io/en/latest/) for more details.
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ environment. In the root directory:
     virtualenv venv
     source venv/bin/activate
 
-Alternatively, if you are using python to manage virtual environments using the `venv` module, then the first line above can be replaced by `python -m venv venv` (where the second `venv` is the virtual environment name).
-
 See [virtualenv docs](https://virtualenv.pypa.io/en/latest/) for more details.
+
+Alternatively, if you are using python to manage virtual environments using the `venv` module, then the first line above can be replaced by `python -m venv venv` (where the second `venv` is the virtual environment name).
 
 *(An alternate `pyproject.toml` file is provided for building with
 [Poetry](https://python-poetry.org/). To use, rename `pyproject-poetry.toml` to


### PR DESCRIPTION
I have also added an explanation of how to use the `venv` python module instead of `virtualenv` as an alternative.