### PR TITLE
Fix the Pylint command in linting CI

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -56,7 +56,7 @@ jobs:
       uses: psf/black@stable
     - name: Lint with pylint
       if: always()
-      run: pylint .
+      run: pylint $(find -type f -name *.py)
     - name: Lint with pydocstyle
       if: always()
       run: pydocstyle --convention=numpy .


### PR DESCRIPTION
There is an error in the current CI workflow:
![image](https://github.com/m2lines/gz21_ocean_momentum/assets/34415979/4299ecc4-23dd-41a4-b07b-3984d6c11bc6)

I updated the command from `pylint .` (which somehow makes pylint look for a `__init__.py` file in the root directory) to `pylint $(find -type f -name *.py)`, so that it can check all python files in the repository.

Related issue: #16 