### PR TITLE
cli/data: properly set Dask workers with CLI opt

### DIFF
--- a/src/gz21_ocean_momentum/cli/data.py
+++ b/src/gz21_ocean_momentum/cli/data.py
@@ -50,7 +50,7 @@ else:
     logger = logging.getLogger(__name__)
 
 if options.dask_workers is not None:
-    dask.config.set(num_workers=1)
+    dask.config.set(num_workers=options.dask_workers)
 
 cli.fail_if_path_is_nonempty_dir(
         1, f"--out-dir \"{options.out_dir}\" invalid", options.out_dir)


### PR DESCRIPTION
Left some debug code in always setting global Dask workers to `1` instead `--dask-workers <int>`.